### PR TITLE
add Model.build_model function

### DIFF
--- a/sentiment_classifier/nlp/models/deep_networks.py
+++ b/sentiment_classifier/nlp/models/deep_networks.py
@@ -13,9 +13,7 @@ class CNN(Model):
             lower=False
         )
 
-    def train(self, reader, filepath):
-        x_train, x_test, y_train, y_test = self._make_training_data(reader)
-
+    def build_model(self, input_shape):
         word_vectors = load_word_vectors(
             filepath="data/wiki-news-300d-1M.vec",
             word_index=self.tokenizer.tokenizer.word_index,
@@ -29,7 +27,7 @@ class CNN(Model):
             trainable=False
         )
 
-        i = layers.Input(shape=(x_train.shape[1],))
+        i = layers.Input(shape=(input_shape,))
         text_embedding = embedding_layer(i)
         convs = []
 
@@ -46,7 +44,12 @@ class CNN(Model):
         concat = layers.concatenate(convs)
         output = layers.Dense(1, activation="sigmoid")(concat)
 
-        self.model = models.Model(inputs=[i], outputs=[output])
+        return models.Model(inputs=[i], outputs=[output])
+
+    def train(self, reader, filepath):
+        x_train, x_test, y_train, y_test = self._make_training_data(reader)
+
+        self.model = self.build_model(input_shape=x_train.shape[1])
 
         self.model.compile(
             loss="binary_crossentropy",

--- a/sentiment_classifier/nlp/models/model.py
+++ b/sentiment_classifier/nlp/models/model.py
@@ -94,6 +94,18 @@ class Model(ABC):
         self.tokenizer = self.tokenizer.load(tokenizer_filepath)
 
     @abstractmethod
+    def build_model(self, input_shape):
+        """ Method for building the model.
+
+        Args:
+            input_shape (int): Size of the input
+
+        Returns:
+            model (keras.Models): a keras model, to be compiled and trained
+        """
+        pass
+
+    @abstractmethod
     def train(self, reader, filepath):
         """ Method for training the model. Must be implemented by
         the subclasses.

--- a/sentiment_classifier/nlp/models/shallow_networks.py
+++ b/sentiment_classifier/nlp/models/shallow_networks.py
@@ -14,12 +14,18 @@ class LogisticRegression(Model):
             lower=True
         )
 
+    def build_model(self, input_shape):
+        i = layers.Input(shape=(input_shape,))
+        h = layers.Dense(units=1, activation="sigmoid")(i)
+
+        model = models.Model(inputs=[i], outputs=[h])
+
+        return model
+
     def train(self, reader, filepath):
         x_train, x_test, y_train, y_test = self._make_training_data(reader)
 
-        i = layers.Input(shape=(x_train.shape[1],))
-        h = layers.Dense(units=1, activation="sigmoid")(i)
-        self.model = models.Model(inputs=[i], outputs=[h])
+        self.model = self.build_model(input_shape=x_train.shape[1])
 
         self.model.compile(loss="binary_crossentropy",
                            optimizer="sgd",


### PR DESCRIPTION
Add a `build_model` function to the base Model class, that builds the model and returns it so that we can compile and train it.

This is cleaner than before, where we where doing everything within the `train` function.