### PR TITLE
Add dataset path to reader

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ h5py==2.9.0
 idna==2.8
 imagesize==1.1.0
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2>=2.10.1
 Keras==2.2.4
 Keras-Applications==1.0.7
 Keras-Preprocessing==1.0.9

--- a/sentiment_classifier/nlp/reader.py
+++ b/sentiment_classifier/nlp/reader.py
@@ -19,9 +19,10 @@ from abc import ABC, abstractmethod
 
 
 class Reader(ABC):
-    def __init__(self):
+    def __init__(self, path):
         self.train_data = None
         self.test_data = None
+        self.path = path
 
     @abstractmethod
     def load_dataset(self, path, limit=None, preprocessing_function=None):
@@ -29,9 +30,8 @@ class Reader(ABC):
 
 
 class IMDBReader(Reader):
-    def __init__(self):
-        super(IMDBReader, self).__init__()
-        self.path = os.path.join("data", "aclImdb")
+    def __init__(self, path):
+        super(IMDBReader, self).__init__(path)
 
     def _read_folder(self, path, label, limit, preprocessing_function):
         """ Read the data from the IMDB dataset folder.

--- a/sentiment_classifier/scripts/train.py
+++ b/sentiment_classifier/scripts/train.py
@@ -7,7 +7,7 @@ from config import PROD_MODEL_FILEPATH
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    imdb = reader.IMDBReader()
+    imdb = reader.IMDBReader(path="./data/aclImdb")
     imdb.load_dataset(
         limit=None,
         preprocessing_function=preprocessing.clean_text

--- a/tests/test_ml.py
+++ b/tests/test_ml.py
@@ -20,7 +20,7 @@ class CommonTests(unittest.TestCase):
         self.assertIsInstance(self.model.tokenizer, tokenizer.BaseTokenizer)
 
     def test_pipeline(self):
-        imdb = reader.IMDBReader()
+        imdb = reader.IMDBReader(path="./data/aclImdb")
         imdb.load_dataset(
             limit=10,
             preprocessing_function=preprocessing.clean_text

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -5,7 +5,7 @@ from nlp.preprocessing import clean_text
 
 
 class TestImdb(unittest.TestCase):
-    imdb = reader.IMDBReader()
+    imdb = reader.IMDBReader(path="./data/aclImdb")
 
     def test_init(self):
         self.assertEqual(TestImdb.imdb.train_data, None)


### PR DESCRIPTION
The dataset path of the `Reader` class was hardcoded to `data/aclImdb`, resulting in a bug if we were running the code from a folder not containing `data`.